### PR TITLE
Add pengWann to the registry

### DIFF
--- a/codes.yaml
+++ b/codes.yaml
@@ -653,3 +653,16 @@ EDRIXS:
         documentation_url: https://nsls-ii.github.io/edrixs/
         title: EDRIXS
         logo: None
+
+pengWann:
+    categories:
+        - tb
+        - io-auto
+    metadata:
+        description: |
+            A lightweight Python package for calculating descriptors of chemical bonding and local electronic structure from Wannier functions.
+        sourcecode_url: https://github.com/PatrickJTaylor/pengWann
+        homepage_url: https://pengwann.readthedocs.io
+        documentation_url: https://pengwann.readthedocs.io
+        title: pengWann
+        logo: https://github.com/PatrickJTaylor/pengWann/raw/main/docs/_static/logo.png


### PR DESCRIPTION
I have recently been working on a small Python package that calculates descriptors of chemical bonding (e.g., the pCOHP/pCOBI implemented in the [LOBSTER](http://www.cohp.de/) code) from Wannier functions as output by Wannier90. If this could be added to the registry, that would be much appreciated :smiley: 